### PR TITLE
Add :inets to extra applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Gelfx.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :inets]
     ]
   end
 


### PR DESCRIPTION
Gelfx implicitly depends on inets from Erlang/OTP. In Elixir 1.11, such a dependency produces compiler warning. This PR corrects that.