### PR TITLE
Feat: Custom log format module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Gelfx
-Elixir logger backend for Graylog based on GELF.  
+
+Elixir logger backend for Graylog based on GELF.
 Documentation is available on [hex.pm](https://hexdocs.pm/gelfx)
 
 <a href="https://frobese.io/" target="_blank"><img src="images/banner-frobeseio.png" alt="frobese.io logo" width="250"/></a>
 
 ## Installation
+
 The package can be installed by adding `gelfx` to your list of dependencies in `mix.exs`:
 
 ```elixir
@@ -14,7 +16,9 @@ def deps do
   ]
 end
 ```
+
 And adding it to your `:logger` configuration in `config.exs`:
+
 ```elixir
 config :logger,
   backends: [
@@ -22,11 +26,38 @@ config :logger,
     Gelfx
   ]
 ```
+
 Since GELF relies on json to encode the payload Gelfx will need a JSON library. By default Gelfx will use Jason which needs to be added to your deps in mix.exs:
+
 ```elixir
     {:jason, "~> 1.0"}
-``` 
+```
+
+### Custom Log Formatter
+
+You can use your own log formatter in the same way you would define one
+for the Elixir default Logger by giving a tuple of your module and a format
+function of arity 4 e.g. `{MyCustomFormatter, :format}`
+
+```elixir
+config :logger, backends: [:console, Gelfx]
+
+config :logger, Gelfx,
+  format: {MyCustomFormatter, :format}
+```
+
+Where your custom logger implements a 4 arity function to format e.g.
+
+```elixir
+defmodule MyCustomFormatter do
+  def format(level, message, timestamp, metadata) do
+    "[custom-formatter][#{level}] #{message}\n"
+  end
+end
+```
+
 ## Features
+
 Gelfx has full support of the Elixir Logger and Gelf/Graylog features.
 
 - Support for __TCP__, __UDP__, and __HTTP__
@@ -39,6 +70,7 @@ Gelfx has full support of the Elixir Logger and Gelf/Graylog features.
 - Support for the `utc_log` Logger option, since GELF expects utc timestamps this has to be handled accordingly
 
 ## Copyright and License
+
 Copyright 2020 Hans Bernhard Gödeke
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/gelfx.ex
+++ b/lib/gelfx.ex
@@ -144,7 +144,7 @@ defmodule Gelfx do
       state
       | compression: Keyword.get(config, :compression),
         connection_timeout: Keyword.get(config, :connection_timeout),
-        format: Formatter.compile(Keyword.get(config, :format)),
+        format: Keyword.get(config, :format),
         host: Keyword.get(config, :host),
         hostname: Keyword.get(config, :hostname),
         json_library: Keyword.get(config, :json_library),

--- a/lib/gelfx/log_entry.ex
+++ b/lib/gelfx/log_entry.ex
@@ -6,7 +6,7 @@ defmodule Gelfx.LogEntry do
 
   @unix_epoch 62_167_219_200
 
-  @default_message_format "[$level] $message\n"
+  @default_message_format "$message"
 
   @loglevel [
     emergency: 0,
@@ -191,21 +191,23 @@ defmodule Gelfx.LogEntry do
         apply(module, func, [level, message, timestamp, metadata])
       else
         _ ->
-          compiled_default_message_format
+          default_formatted_full_message(level, message, timestamp, metadata)
       end
     rescue
       _ ->
-        compiled_default_message_format
+        default_formatted_full_message(level, message, timestamp, metadata)
     end
   end
 
   defp formatted_full_message(format, level, message, timestamp, metadata) do
     format
+    |> Formatter.compile()
     |> Formatter.format(level, message, timestamp, metadata)
     |> IO.chardata_to_string()
   end
 
-  defp compiled_default_message_format do
-    Logger.Formatter.compile(@default_message_format)
+  defp default_formatted_full_message(level, message, timestamp, metadata) do
+    @default_message_format
+    |> formatted_full_message(level, message, timestamp, metadata)
   end
 end

--- a/test/gelfx/log_entry_test.exs
+++ b/test/gelfx/log_entry_test.exs
@@ -45,5 +45,25 @@ defmodule Gelfx.LogEntryTest do
       assert entry["_email"] == "email@test.local"
       assert entry["_meta"] == "test"
     end
+
+    test "uses default log message if issues with custom logger format" do
+      event =
+        {4, nil,
+         {Logger, "test-message", {{2021, 01, 01}, {01, 01, 01, 01}},
+          [email: "email@test.local"]}}
+
+      entry = Gelfx.LogEntry.from_event(event, %Gelfx{
+        format: {TestFormatter, :bad_format},
+        hostname: "test.local",
+        utc_log: true,
+        metadata: []
+      })
+      assert entry[:full_message] == "test-message"
+      assert entry[:host] == "test.local"
+      assert entry[:short_message] == "test-message"
+      assert entry[:timestamp]
+      assert entry[:version]
+      assert entry["_email"] == "email@test.local"
+    end
   end
 end

--- a/test/test_helper/test_formatter.ex
+++ b/test/test_helper/test_formatter.ex
@@ -1,0 +1,7 @@
+defmodule TestFormatter do
+  def format(level, message, timestamp, metadata) do
+    "[test-logger][#{level}] #{message}\n"
+  rescue
+    _ -> "could not format message!\n"
+  end
+end


### PR DESCRIPTION
## What

When trying to use a custom module to format logs the current log entry is unable to handle this use-case. Allow users to configure the `format` option with a custom module and function e.g. `{MyCustomFormatter, :format}` would invoke `MyCustomFormatter.format` if the format function is arity 4 and defined as `def format(level, message, timestamp, metadata)`.

## Changes

- Handle `{module, function}` values for the `format` option
- Add tests for a custom format module.

## Concerns or Call-outs

- Is there a better way to invoke a custom format function?